### PR TITLE
Fix error with data utilization below one percent

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ async function scrape(cookieJar) {
     const daysLeft = /"dumDaysLeft": "(\d*)"/.exec(body)[1]
     const limit = /"dumLimit": "(\d*)"/.exec(body)[1]
     const usage = /"dumUsage": "(\d*)"/.exec(body)[1]
-    const utilization = /"dumUtilization": "(\d*)"/.exec(body)[1]
+    const utilization = /"dumUtilization": "(<?\d*)"/.exec(body)[1]
 
     return {
       daysLeft,


### PR DESCRIPTION
This fixes a scrape failure when the data utilization is less that one percent.

```
Error: Scrape failed: Error: Scrape failed, Err: TypeError: Cannot read property '1' of null
    at scrape.catch.err (index.js:26:13)
```
When this happens on the website, the string is: "<1%"